### PR TITLE
Dynamic grid

### DIFF
--- a/client/src/components/game/Board.tsx
+++ b/client/src/components/game/Board.tsx
@@ -16,6 +16,7 @@ export const Board: React.FC = () => {
     isTie,
     setIsTie,
     incrementTotalGames,
+    gridSize,
   } = useGameContext();
 
   const { players, setPlayers } = usePlayerContext();
@@ -30,7 +31,7 @@ export const Board: React.FC = () => {
         i === index ? currentPlayer.symbol : square
       );
 
-      const winnerSymbol = calculateWinner(newSquares);
+      const winnerSymbol = calculateWinner(newSquares, gridSize);
       if (winnerSymbol) {
         setWinner((prevWinner) => {
           const winningPlayer = players.find(
@@ -62,7 +63,7 @@ export const Board: React.FC = () => {
       <div className="w-full flex justify-start">
         <Status winner={winner} currentPlayer={currentPlayer} />
       </div>
-      <div className="grid grid-cols-3 gap-4 mb-4">
+      <div className={`grid grid-cols-${gridSize} gap-4 mb-4`}>
         {squares.map((square, index) => (
           <Cell key={index} value={square} onClick={() => handleClick(index)} />
         ))}

--- a/client/src/components/game/Game.tsx
+++ b/client/src/components/game/Game.tsx
@@ -2,13 +2,15 @@ import React, { Dispatch, SetStateAction } from "react";
 import { Board } from "./Board";
 import { Controls } from "./Controls";
 import { GameOver } from "./GameOver";
+import { GridSizeInput } from "./GridSizeInput";
 
 export const Game: React.FC = () => {
   return (
     <div className="flex flex-col items-center lg:justify-center lg:items-start mt-10">
       <div className="flex flex-col items-center">
         <Board />
-        <div className="w-full flex justify-end mt-4">
+        <div className="w-full flex justify-between mt-4">
+          <GridSizeInput />
           <Controls />
         </div>
       </div>

--- a/client/src/components/game/GridSizeInput.tsx
+++ b/client/src/components/game/GridSizeInput.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { useGameContext } from "../../context/GameProvider";
+
+export const GridSizeInput: React.FC = () => {
+  const { gridSize, setGridSize } = useGameContext();
+
+  /** @todo
+   * restricting to max grid size as 5, as layout is breaking - need to fix it
+   */
+  const handleGridSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Math.max(3, Math.min(5, Number(e.target.value)));
+    setGridSize(value);
+  };
+
+  return (
+    <div className="flex flex-col items-center mb-4 ">
+      <input
+        type="number"
+        value={gridSize}
+        onChange={handleGridSizeChange}
+        className="w-16 text-center p-1 border rounded text-blue-950 "
+        min={3}
+        max={15}
+      />
+    </div>
+  );
+};

--- a/client/src/context/GameProvider.tsx
+++ b/client/src/context/GameProvider.tsx
@@ -21,6 +21,8 @@ interface GameContextType {
   handleReset: () => void;
   totalGames: number;
   incrementTotalGames: () => void;
+  gridSize: number;
+  setGridSize: (size: number) => void;
 }
 
 const GameContext = createContext<GameContextType | undefined>(undefined);
@@ -40,14 +42,17 @@ interface GameProviderProps {
 export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
   const { players, setPlayers } = usePlayerContext();
 
-  const [squares, setSquares] = useState<SquareType[]>(Array(9).fill(null));
+  const [gridSize, setGridSize] = useState<number>(3);
+  const [squares, setSquares] = useState<SquareType[]>(
+    Array(gridSize * gridSize).fill(null)
+  );
   const [currentPlayerIndex, setCurrentPlayerIndex] = useState<number>(0);
   const [winner, setWinner] = useState<Player | null>(null);
   const [isTie, setIsTie] = useState<boolean>(false);
   const [totalGames, setTotalGames] = useState<number>(0);
 
   const handleReset = () => {
-    setSquares(Array(9).fill(null));
+    setSquares(Array(gridSize * gridSize).fill(null));
     setWinner(null);
     setIsTie(false);
     setCurrentPlayerIndex((prevIndex) =>
@@ -57,6 +62,14 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
 
   const incrementTotalGames = () => {
     setTotalGames(totalGames + 1);
+  };
+
+  const updateGridSize = (size: number) => {
+    setGridSize((s) => size);
+    setSquares(Array(size * size).fill(null));
+    setWinner(null);
+    setIsTie(false);
+    setCurrentPlayerIndex(0);
   };
 
   return (
@@ -73,6 +86,8 @@ export const GameProvider: React.FC<GameProviderProps> = ({ children }) => {
         handleReset,
         totalGames,
         incrementTotalGames,
+        gridSize,
+        setGridSize: updateGridSize,
       }}
     >
       {children}

--- a/client/src/utils/calculateWinner.ts
+++ b/client/src/utils/calculateWinner.ts
@@ -1,13 +1,13 @@
 import { SquareType, XorO } from '../types';
 
-export const calculateWinner = (squares: SquareType[]): XorO | null => {
-  
-  const lines =generateRowColumnPairs(3)
 
-  for (let i = 0; i < lines.length; i++) {
-    const [a, b, c] = lines[i];
-    if (squares[a] && squares[a] === squares[b] && squares[a] === squares[c]) {
-      return squares[a];
+
+export const calculateWinner = (squares: SquareType[], gridSize: number): XorO | null => {
+  const winningLines = generateRowColumnPairs(gridSize);
+  for (const line of winningLines) {
+    const [first, ...rest] = line;
+    if (squares[first] && rest.every(index => squares[index] === squares[first])) {
+      return squares[first];
     }
   }
   return null;

--- a/client/src/views/TicTacToe.tsx
+++ b/client/src/views/TicTacToe.tsx
@@ -4,19 +4,17 @@ import { PlayerStats } from "../components/player/PlayerStats";
 import { PlayerProvider } from "../context/PlayerProvider";
 import { GameProvider } from "../context/GameProvider";
 
-export const TicTacToe: React.FC = () => {
-  return (
-    <PlayerProvider>
-      <GameProvider>
-        <div
-          className={`h-screen flex flex-col items-center justify-center p-4 text-black dark:text-white`}
-        >
-          <div className="flex flex-col lg:flex-row ">
-            <Game />
-            <PlayerStats />
-          </div>
+export const TicTacToe: React.FC = () => (
+  <PlayerProvider>
+    <GameProvider>
+      <div
+        className={`h-screen flex flex-col items-center justify-center p-4 text-black dark:text-white`}
+      >
+        <div className="flex flex-col lg:flex-row ">
+          <Game />
+          <PlayerStats />
         </div>
-      </GameProvider>
-    </PlayerProvider>
-  );
-};
+      </div>
+    </GameProvider>
+  </PlayerProvider>
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic-game",
+  "name": "dynamic-grid",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
feat: Add dynamic grid size support for Tic-Tac-Toe game

- Modified `Board` component to use the dynamic grid size from context and render the grid accordingly.
- Ensured the game logic adapts to changes in grid size, including resetting and updating state.

Todo:
- Improve UI responsiveness and handling of grid size changes.

Issues:
- Max grid size is 5


<img width="1487" alt="image" src="https://github.com/afsalmarattil/tic-tac-toe/assets/8337527/02ff8dfd-4472-4537-bb94-9819bf0c5ab3">
